### PR TITLE
Fix for #1

### DIFF
--- a/scripts/Mosaic_Creator.py
+++ b/scripts/Mosaic_Creator.py
@@ -82,7 +82,10 @@ def createPhotomosaic(target_image, input_images, grid_size,
     batch_size = int(len(target_images) / 10)
     avgs = []
     for img in input_images:
-        avgs.append(getAverageRGB(img))
+        try:
+            avgs.append(getAverageRGB(img))
+        except ValueError:
+            continue
 
     for img in target_images:
         avg = getAverageRGB(img)


### PR DESCRIPTION
Wrap call to `getAverageRGB` in a try ... except block to simply skip invalid images