### PR TITLE
Fixed abnoma Alpha of output img. Fixed a potential issues. 

### DIFF
--- a/scripts/Mosaic_Creator.py
+++ b/scripts/Mosaic_Creator.py
@@ -115,6 +115,9 @@ def createPhotomosaic(target_image, input_images, grid_size,
         try:
             avgs.append(getAverageRGB(img))
         except ValueError:
+            # If no append inf, avgs_index and  input_imgs_index will not correspond
+            avgs.append((float("inf"),float("inf"),float("inf")))   
+            print("An unsafe img is found, you may need to run Image_Tester.py to delete it")
             continue
 
     grid_indices = np.arange(len(target_images))

--- a/scripts/Mosaic_Creator.py
+++ b/scripts/Mosaic_Creator.py
@@ -34,14 +34,6 @@ def getImages(images_directory,alpha_input):
         try:
             fp = open(filePath, "rb")
             im = Image.open(fp)
-
-            if not alpha_input[0] == 255:
-                # in alpha[0] not default(255), reset alpha of every img
-                im=im.convert("RGBA")
-                r, g, b, alpha = im.split()
-                alpha = alpha.point(lambda i: i>0 and alpha_input[0])
-                im.putalpha(alpha)
-      
             images.append(im)
             im.load()
             fp.close()
@@ -136,21 +128,21 @@ def createPhotomosaic(target_image, input_images, grid_size,
 
     mosaic_image = createImageGrid(output_images, grid_size)
 
-    if not alpha_input[1] == 0:
-        
-        # reset the alpha layer of target_image
-        target_image = target_image.convert("RGBA")
-        r, g, b, alpha = target_image.split()
-        alpha = alpha.point(lambda i: i>0 and alpha_input[1])
-        target_image.putalpha(alpha)
+    mosaic_image = mosaic_image.convert("RGBA")   #default 255
+    target_image = target_image.convert("RGBA")
 
-        # resize the target_image, matching the final out-img
-        target_image = target_image.resize(mosaic_image.size)
+    # resize the target_image, matching the final out-img
+    target_image = target_image.resize(mosaic_image.size)
 
-        # merge target_image and Composite img
-        result_image = Image.alpha_composite(mosaic_image, target_image)
-        return (result_image)
-    
+    if not alpha_input[0] == 255:
+        mosaic_image.putalpha(alpha_input[0])
+
+    if not alpha_input[1] == 255:
+        target_image.putalpha(alpha_input[1])
+
+
+    # merge target_image and Composite img
+    mosaic_image = Image.alpha_composite(mosaic_image, target_image)    # RGBA
     return (mosaic_image)
 
 

--- a/scripts/Mosaic_Creator.py
+++ b/scripts/Mosaic_Creator.py
@@ -16,7 +16,7 @@ parser.add_argument('--no-resize', dest='resize', action='store_false')
 parser.set_defaults(resize=True)
 parser.add_argument('--shuffle', dest='shuffle', action='store_true',help='Whether shuffle the sequence when setting the grids')
 parser.set_defaults(shuffle=False)
-parser.add_argument('--alpha', nargs=2, dest='alpha', type=int, help='The alpha for images and target-image, The alpha values for images and target-image, in the range [0, 255]')
+parser.add_argument('--alpha', nargs=2, dest='alpha', type=int, help='The alpha values for images and target-image, in the range [0, 255]')
 parser.set_defaults(alpha=[255, 0])
 parser.add_argument('--magnify', nargs=1, dest='magnification', type=float, help='Enlarge the final out_img, float type')
 parser.set_defaults(magnification=(1.0,))
@@ -26,7 +26,7 @@ args = parser.parse_args()
 
 MATCH_INDECES = []
 
-def getImages(images_directory,alpha_input):
+def getImages(images_directory):
     files = os.listdir(images_directory)
     images = []
     for file in files:
@@ -148,14 +148,14 @@ def createPhotomosaic(target_image, input_images, grid_size,
 
 ### ---------------------------------------------
 
-# alpha value of ..
+# alpha value of imgs and target_img
 alpha_input = args.alpha
 
 target_image = Image.open(args.target)
 
 # input images
 print('reading input folder...')
-input_images = getImages(args.images,alpha_input)
+input_images = getImages(args.images)
 
 # check if any valid input images found
 if input_images == []:
@@ -208,11 +208,7 @@ if resize_input:
 mosaic_image = createPhotomosaic(target_image, input_images, grid_size, reuse_images,shuffle_input,alpha_input)
 
 # write out mosaic
-if alpha_input == [255, 0]:
-    mosaic_image.convert("RGB").save(output_filename, 'jpeg')  #defalut, no alpha, always discard alpha
-else:
-    mosaic_image.save(output_filename, 'png')   #customer alpha
-
+mosaic_image.convert("RGB").save(output_filename, 'jpeg') # always output as jpeg to handle incorrect alpha band
 
 print("saved output to %s" % (output_filename,))
 print('done.')


### PR DESCRIPTION
1. Fixed a long-standing potential issue: when `Image_Tester.py` is not executed in advance and there are unsafe images, which lead to abnormal output.

   The line `avgs.append(getAverageRGB(img))` in case of an exception will result in the length of `avgs` being less than the length of `input_images`, causing **index confusion** and abnormal output.

2. Fixed incorrect alpha blending. 

   For example, two pixels that are not totally opaque (less than 255), no matter how they are overlaid, will remain not totally opaque. Therefore, we always output as RGB (jpeg).

3. Optimization coding. Since the script only consider the RGB channels when matching images, we can set and  blend the alpha channel at the end to enhance code readability.